### PR TITLE
Fix: update WorldGuard hook initialization check (Issue #1409)

### DIFF
--- a/src/main/java/org/mineacademy/boss/BossPlugin.java
+++ b/src/main/java/org/mineacademy/boss/BossPlugin.java
@@ -98,7 +98,7 @@ public final class BossPlugin extends BukkitPlugin {
 		DiskRegion.setCreatedPlayerRegionGetter(player -> PlayerCache.from(player).getCreatedRegion());
 		DiskRegion.setCreatedPlayerRegionResetter(player -> PlayerCache.from(player).setCreatedRegion(new VisualizedRegion()));
 
-		if (MinecraftVersion.atLeast(V.v1_16) && Platform.isPluginInstalled("WorldGuard"))
+		if (MinecraftVersion.atLeast(V.v1_16) && Bukkit.getPluginManager().getPlugin("WorldGuard") != null)
 			WorldGuardHook.init();
 	}
 


### PR DESCRIPTION
Issue #1409

The plugin was previously checking if WorldGuard was already enabled during the loading phase. However, since Boss depends on WorldGuard, it will always be loaded after it—but that doesn’t guarantee WorldGuard is enabled during Boss’s loading phase.

My initial approach was to move the WorldGuard hook to the plugin's onEnable() method. However, this resulted in an error, as it turns out that WorldGuard integration must be initialized during the loading phase.

This led me to uncover an issue in BukkitPlatform.isPluginInstalled(pluginName):
The method schedules a task to check whether the plugin is enabled after the server has fully started, but the task is executed immediately rather than being properly deferred—defeating its purpose.

I attempted to fix this scheduling behavior, but couldn't achieve the intended result of running the hook only after full server startup.

Instead, I simplified the check: it now only verifies whether WorldGuard is present in the plugin list during the loading phase, without checking if it's enabled at that point.

In my tests, WorldGuard integration still works as expected with this approach.